### PR TITLE
Zen

### DIFF
--- a/parser/fenec_test.go
+++ b/parser/fenec_test.go
@@ -1,0 +1,48 @@
+// Test the fenec specific grammer in the parser
+
+package parser
+
+import (
+	"go/ast"
+	"go/token"
+	"testing"
+
+	"github.com/nordsieck/defect"
+)
+
+func TestEmptyGenerics_literals(t *testing.T) {
+	src := []string{
+		"struct{}{}",   // empty struct
+		"struct[]{}{}", // empty generic struct
+
+		"func(){}",   // empty function
+		"func[](){}", // empty generic function
+	}
+
+	for _, s := range src {
+		_, err := ParseExpr(s)
+		defect.Equal(t, err, nil)
+	}
+}
+
+func TestEmptyGenerics_vars(t *testing.T) {
+	preamble := "package main;"
+
+	src := []string{
+		"func f(){}",         // empty function
+		"func f[](){}",       // empty generic function
+		"func (r R) f(){}",   // empty method
+		"func (r R) f[](){}", // empty generic method
+	}
+
+	for _, s := range src {
+		_ = ParseTestFile(t, preamble+s)
+	}
+}
+
+func ParseTestFile(t *testing.T, s string) *ast.File {
+	fset := token.NewFileSet()
+	file, err := ParseFile(fset, "", s, AllErrors)
+	defect.Equal(t, err, nil)
+	return file
+}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -747,6 +747,12 @@ func (p *parser) parseStructType() *ast.StructType {
 	}
 
 	pos := p.expect(token.STRUCT)
+
+	if p.tok == token.LBRACK {
+		p.expect(token.LBRACK)
+		p.expect(token.RBRACK)
+	}
+
 	lbrace := p.expect(token.LBRACE)
 	scope := ast.NewScope(nil) // struct scope
 	var list []*ast.Field
@@ -906,6 +912,10 @@ func (p *parser) parseSignature(scope *ast.Scope) (params, results *ast.FieldLis
 		defer un(trace(p, "Signature"))
 	}
 
+	if p.tok == token.LBRACK {
+		p.expect(token.LBRACK)
+		p.expect(token.RBRACK)
+	}
 	params = p.parseParameters(scope, true)
 	results = p.parseResult(scope)
 


### PR DESCRIPTION
Implement empty generics

This will eventually be phased out, but it's a stepping stone to unqualified generics.
